### PR TITLE
Add Repository Citation Support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "McDermott"
+  given-names: "Matthew"
+  email: "mattmcdermott8@gmail.com"
+  orcid: "https://orcid.org/0000-0001-6048-9707"
+title: "MIMIC-IV MEDS: An ETL pipeline to extract MIMIC-IV data into the MEDS format"
+version: "0.0.6"
+date-released: 2025-05-13
+url: "https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS"
+repository-code: "https://github.com/Medical-Event-Data-Standard/MIMIC_IV_MEDS"
+license: MIT
+keywords:
+  - medical-data
+  - healthcare
+  - ETL
+  - MEDS
+  - MIMIC-IV
+  - electronic-health-records
+abstract: "This pipeline extracts the MIMIC-IV dataset (from physionet) into the MEDS (Medical Event Data Standard) format, providing a standardized approach to processing electronic health record data for research and analysis."
+type: software

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ MEDS dataset are retained in additional folders. See
 [this github issue](https://github.com/Medical-Event-Data-Standard/MEDS_transforms/issues/235) for tracking on ensuring these
 directories are automatically cleaned up in the future.
 
+## 📚 Citing this work
+
+If you use this software in your research, please cite it! You can use the **"Cite this repository"** button on GitHub.
+
+The citation information is maintained in the `CITATION.cff` file in this repository.
+
 ## 🔧 Common Issues / FAQ
 
 ### ❓ Issue: `FileNotFoundError` or pipeline errors during the `pre_MEDS` step on Ubuntu (symlinks not recognized)

--- a/scripts/update_citation.py
+++ b/scripts/update_citation.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Update CITATION.cff with latest GitHub release."""
+
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+
+def main():
+    # Find citation file
+    script_dir = Path(__file__).parent
+    citation_file = script_dir.parent / "CITATION.cff"
+
+    # Get latest release
+    url = "https://api.github.com/repos/Medical-Event-Data-Standard/MIMIC_IV_MEDS/releases/latest"
+    with urllib.request.urlopen(url) as r:
+        data = json.loads(r.read().decode())
+
+    version = data["tag_name"].lstrip("v")
+    date = data["published_at"].split("T")[0]
+
+    # Update file
+    content = citation_file.read_text()
+    content = re.sub(r'version: "[^"]*"', f'version: "{version}"', content)
+    content = re.sub(r"date-released: \d{4}-\d{2}-\d{2}", f"date-released: {date}", content)
+    citation_file.write_text(content)
+
+    print(f"✅ Updated: v{version} ({date})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+
+def test_citation_file():
+    """Test CITATION.cff file exists and has required fields."""
+    citation_file = Path(__file__).parent.parent / "CITATION.cff"
+    content = citation_file.read_text()
+
+    required = ["cff-version", "message", "authors", "title", "version", "date-released", "url"]
+    missing = [field for field in required if not re.search(f"^{field}:", content, re.MULTILINE)]
+
+    assert not missing, f"Missing fields: {', '.join(missing)}"
+    assert re.search(r"date-released: \d{4}-\d{2}-\d{2}", content), "Invalid date format"
+
+
+def test_github_api():
+    """Test that GitHub API returns valid data."""
+    url = "https://api.github.com/repos/Medical-Event-Data-Standard/MIMIC_IV_MEDS/releases/latest"
+    with urllib.request.urlopen(url) as r:
+        data = json.loads(r.read().decode())
+
+    assert "tag_name" in data, "Missing tag_name"
+    assert "published_at" in data, "Missing published_at"
+
+    version = data["tag_name"].lstrip("v")
+    date = data["published_at"].split("T")[0]
+
+    assert re.match(r"\d+\.\d+\.\d+", version), f"Invalid version: {version}"
+    assert re.match(r"\d{4}-\d{2}-\d{2}", date), f"Invalid date: {date}"


### PR DESCRIPTION
## Add Repository Citation Support

Fixes #9

### 🎯 What this does:
- Adds `CITATION.cff` with proper author info and ORCID
- GitHub will automatically show **"Cite this repository"** button
- Includes maintenance script to update version/date from releases

### 🚀 Usage:
Users can now cite this repository using the GitHub button, or manually reference the CFF file.

To update citation after releases:
```bash
python scripts/update_citation.py
```

### ✅ Tested:
- Citation file format validation
- GitHub API integration
- Script functionality